### PR TITLE
Add SITE.md for the website course description

### DIFF
--- a/SITE.md
+++ b/SITE.md
@@ -1,0 +1,5 @@
+# AI Dev Tools Zoomcamp
+
+AI Dev Tools Zoomcamp is a completely free, hands-on course on using modern AI tools to write better code, faster. Across six modules you work with chat applications and coding assistants, build an end-to-end application, give assistants tools through the Model-Context Protocol, build your own coding agent, apply AI to testing and CI/CD, and automate everyday workflows with low-code tools.
+
+Each module has video lectures and a homework assignment, and the course finishes with a project of your own, built end to end with AI tools.

--- a/course.yaml
+++ b/course.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 content_id: 10000000-0000-4000-8000-000000000002
 slug: ai-dev-tools-zoomcamp
 title: AI Dev Tools Zoomcamp
-description_path: README.md
+description_path: SITE.md
 outcome: Build disciplined software workflows with AI assistants, agents, testing, and automation.
 repository_url: https://github.com/DataTalksClub/ai-dev-tools-zoomcamp
 docs_url: https://datatalks.club/docs/courses/ai-dev-tools-zoomcamp/


### PR DESCRIPTION
Adds `SITE.md`, a short course description written for the DataTalks.Club website, and points `course.yaml` at it.

**Why:** the website takes this course's description from the repository via `description_path` in `course.yaml`, which currently reads `README.md`. The README is written for a GitHub audience, so the website ends up rendering badges, centered HTML and contributor lists. `SITE.md` gives the website a file whose only job is to be that copy.

**Changes**

- New `SITE.md` with the website description.
- `course.yaml`: `description_path: README.md` -> `description_path: SITE.md`. No other field is touched, `content_id` included.

Both are in the same commit on purpose: the file without the pointer does nothing, and the pointer without the file would break the import.

**Notes**

- `README.md` is unchanged.
- The copy is condensed from the existing DataTalks.Club course page for this course in `DataTalksClub/docs` (`courses/ai-dev-tools-zoomcamp/`). It is a shortened version of authored copy rather than new marketing text, but it is worth an owner read before merging.
